### PR TITLE
Shift + Tab で直前の Tab を削除

### DIFF
--- a/ktm.html
+++ b/ktm.html
@@ -844,11 +844,27 @@ var DIAGRAM_MARGIN=10,ACTOR_MARGIN=10,ACTOR_PADDING=10,SIGNAL_MARGIN=5,SIGNAL_PA
 		if (e.which == 9 || e.keyCode == 9) {
 			e.preventDefault();
 			var pos = this.selectionStart;
+			var nextPos = pos;
 			var text = $(this).val();
-			// tabの挿入
-			$(this).val(text.substr(0,pos) + '\t' + text.substr(pos, text.length));
+			var editedText = text;
+			var before = text.substr(0, pos);
+			var after = text.substr(pos, text.length);
+
+			if (e.shiftKey) {
+				if (before.match(/\t$/)) {
+					// 直前のtabを削除
+					editedText = before.slice(0, -1) + after;
+					nextPos--;
+				}
+			} else {
+				// tabの挿入
+				editedText = before + '\t' + after;
+				nextPos++;
+			}
+			
+			$(this).val(editedText);
 			// カーソルの場所を移動
-			this.setSelectionRange(pos + 1, pos + 1);
+			this.setSelectionRange(nextPos, nextPos);
 		}
 	});
 	


### PR DESCRIPTION
素晴らしいエディタをありがとうございます。
仕事で、メンバー向けのちょっとした説明資料などに使わせて頂いています。

使っていて少し動作が気になったのでプルリクエストを作りました。

`tab` キーでタブが入力されるようになったのは凄く嬉しかったのですが、 `shift` + `tab` を入力しても同じようにタブが入力される動作が少し気になりました。
直前のタブが消えれば自然かなと感じたので、 `shift` を押している場合は直前のタブを削除するようにしてみました。

もしよろしければ、マージしていただければ幸いです。

一応、以下のブラウザで動作することは確認しています。
- Chrome `48.0.2564.97 m`
- Firefox `44.0`
- IE `11.0.9600.78163`

OS は Windows 7 です。

以上です、よろしくお願いします。
